### PR TITLE
GOG Fix and Improved Memory Failsafe

### DIFF
--- a/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Characters.java
+++ b/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Characters.java
@@ -255,7 +255,7 @@ public class Characters
         return newCharacter;
     }
     
-    public static ArrayList<Characters> importChar (String name,int compressedOrNot) throws IOException
+    public static ArrayList<Characters> importChar (String name,int compressedOrNot,int cutoff) throws IOException
     {
 
         String tab = "	";
@@ -433,6 +433,7 @@ public class Characters
                     try {
                         int charNum = Integer.parseInt(qaaa.split("=")[0]);
                         if (charNum == baCharacters.size()+1) { //Somehow has gone past checks, immediately end
+                            //if (charNum == idCount+1) { //Somehow has gone past checks, immediately end
                             aqq = aqq + 1;
                             flag = 1; //end loop
                             output[6] = "0";
@@ -486,6 +487,7 @@ public class Characters
                         
                         ArrayList<Integer> tmpChildren = new ArrayList<Integer>();
                         String childrenArray[] = tmpOutput[15].split(" ");
+                        
                         aq2 = 0;
                         while (aq2 < childrenArray.length) {
                             int selectedChild = Integer.parseInt(childrenArray[aq2]);
@@ -501,6 +503,19 @@ public class Characters
                         int tmpMother = Integer.parseInt(tmpOutput[21]);
                         int tmpFather = Integer.parseInt(tmpOutput[22]);
                         
+                        if (cutoff > -1) { //if relatives are above the cutoff point, purge in order to save memory
+                            //Children will never have an ID higher then their parents
+                            if (tmpSpouse < cutoff) {
+                                tmpSpouse = -1;
+                            }
+                            if (tmpMother < cutoff) {
+                                tmpMother = -1;
+                            }
+                            if (tmpFather < cutoff) {
+                                tmpFather = -1;
+                            }
+                        }
+                        
                         Characters convertedCharacter = newCharacter(idCount,tmpOutput[1],tmpOutput[2],tmpOutput[4],dynID,traitsList,
                         tmpM,tmpF,tmpC,tmpZ,tmpSpouse,tmpChildren,tmpCorruption,tmpOutput[18],tmpOutput[19],tmpAge,tmpOutput[0],tmpCountry,tmpMother,
                         tmpFather);
@@ -509,7 +524,12 @@ public class Characters
                             convertedCharacter.setDynastyName("minor_"+tmpOutput[16]);
                         }
                         
-                        baCharacters.add(convertedCharacter);
+                        if (cutoff <= -1 || idCount >= cutoff) { //Only add to memory if above the cutoff point
+                            baCharacters.add(convertedCharacter);
+                        } else {
+                            baCharacters.add(null);
+                        }
+                        
                         
                         idCount = idCount + 1;
 
@@ -541,12 +561,7 @@ public class Characters
         }catch (java.util.NoSuchElementException exception){
             endOrNot = false;
 
-        }catch (java.lang.OutOfMemoryError exception){
-            endOrNot = false;
-            System.out.println("Error! Out of Memory, ending character conversion.");
-            System.out.println("Characters cut at "+idCount+", this may cause issues!");
-
-        } 
+        }
 
         return baCharacters;
 
@@ -752,7 +767,7 @@ public class Characters
         while (count < baCharacters.size()) {
             Characters selectedCharacter = baCharacters.get(count);
             int tmpHighestID = 0;
-            if (!selectedCharacter.isPruned()) {
+            if (selectedCharacter != null && !selectedCharacter.isPruned()) {
                 tmpHighestID = selectedCharacter.getIrID();
                 if (tmpHighestID > highestID) {
                     highestID = tmpHighestID;

--- a/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Directories.java
+++ b/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Directories.java
@@ -235,5 +235,42 @@ public class Directories
         }
         return null;
     }
+    
+    public static String removeGameFromDir(String irDir) throws IOException //GOG auto-detection sometimes adds "game" to the end of the I:R Dir
+    {
+        try {
+            String VN = "//";
+            VN = VN.substring(0,1);
+            String VM = "\\";
+            VM = VM.substring(0);
+            String newIrDir = irDir.replace(VN,"~~~");
+            newIrDir = newIrDir.replace(VN,"~~~");
+            
+            String[] splitIRDir = newIrDir.split("~~~");
+            String end = splitIRDir[splitIRDir.length-1];
+            
+            if (end.equals("game")) {
+                int count = 0;
+                String newerDir = "";
+                while (count < splitIRDir.length-1) {
+                   String component = splitIRDir[count];
+                   if (count == 0) {
+                       newerDir = component + "/";
+                   } else {
+                       newerDir = newerDir + component + "/";
+                   }
+                   count = count + 1;
+                }
+                System.out.println("/game/ removed from input I:R Directory");
+                return newerDir;
+            }
+        }
+        
+        catch (Exception e) {
+            System.out.println("Warning, something went wrong reading "+irDir+", attempting to convert anyway");
+        }
+        
+        return irDir;
+    }
 
 }

--- a/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Main.java
+++ b/BaToImperator/src/main/java/com/paradoxgameconverters/batoir/Main.java
@@ -57,6 +57,12 @@ public class Main
             //LOGGER.info("Please input your system profile username");
 
             String[] configDirectories = Importer.importDir("configuration.txt");
+            int configCount = 0;
+            while (configCount < configDirectories.length) {
+                LOGGER.info("configuration setting "+configCount+" is "+configDirectories[configCount]);
+                configCount = configCount + 1;
+            }
+            
             String VM = "\\";
             VM = VM.substring(0);
             String VN = "//";
@@ -82,6 +88,8 @@ public class Main
             int irProvTot = 15000;
 
             String impGameDir = configDirectories[1];
+            
+            impGameDir = Directories.removeGameFromDir(impGameDir); // removes "game from Dir"
 
             //String baDir = configDirectories[0];
 
@@ -125,10 +133,6 @@ public class Main
 
             int[] ck2LandTot;   // The ammount of land each country has
             ck2LandTot = new int[5000];
-
-            ArrayList<String> convertedCharacters = new ArrayList<String>(); //characters who have been converted
-
-            convertedCharacters.add("0"); //Debug at id 0 so list will never be empty
 
             ArrayList<Diplo> impSubjectInfo = new ArrayList<Diplo>(); //Overlord-Subject relations
 
@@ -742,7 +746,13 @@ public class Main
             int firstAvailableCharID = Characters.getAvailableID(gameFileDir);
             
             ArrayList<Characters> baCharacters = new ArrayList<Characters>();
-            baCharacters = Characters.importChar(saveCharacters,compressedOrNot);
+            int cutoffNum = 450000;
+            try {
+                baCharacters = Characters.importChar(saveCharacters,compressedOrNot,-1);
+            } catch (java.lang.OutOfMemoryError exception){ //Replace likely long-dead characters with null as a fail-safe for memory-related crashes
+                LOGGER.warning("Error! Ran out of memory while converting characters, attempting to purge characters below ID "+cutoffNum+".");
+                baCharacters = Characters.importChar(saveCharacters,compressedOrNot,cutoffNum);
+            } 
             
             if (pruneLevel <= 5) {
                 baCharacters = Processing.pruneCharactersExtreme(baCharacters,baTagInfo,pruneLevel);


### PR DESCRIPTION
GOG detection sometimes adds "game" to the end of the I:R Dir, causing issues when attempting to locate vanilla game files. To fix this, a new removeGameFromDir function has been added which removes the word "game" from the end of a directory. Secondly, instead of just simply stopping character importation and likely crashing if the converter runs out of memory, the previous 450,000 characters will be nullified, taking significantly less space in memory. Finally, user configuration is now posted into the log, eliminating the need to get users reporting bugs to submit their configuration.txt file.